### PR TITLE
Add module to measure the XP fame of the users by a specific XP goal

### DIFF
--- a/VGXPBotCore/Modules/GetStatsModule.cs
+++ b/VGXPBotCore/Modules/GetStatsModule.cs
@@ -55,7 +55,7 @@ namespace VGXPBotCore.Modules
               using (SQLiteDataReader dbDataReader = dbCommand.ExecuteReader())
               {
 
-                //Read settings info
+                //Read user stats info
                 dbDataReader.Read();
 
                 //Create and set embed object
@@ -171,7 +171,7 @@ namespace VGXPBotCore.Modules
               using (SQLiteDataReader dbDataReader = dbCommand.ExecuteReader())
               {
 
-                //Read settings info
+                //Read user stats info
                 dbDataReader.Read();
 
                 //Create and set embed object

--- a/VGXPBotCore/Modules/GoalModule.cs
+++ b/VGXPBotCore/Modules/GoalModule.cs
@@ -25,7 +25,7 @@ namespace VGXPBotCore.Modules
     public async Task GoalAsync(int goal)
     {
 
-      //Create and set users list
+      //Create and set SocketUser object
       SocketUser user;
 
       //Create and set embed object

--- a/VGXPBotCore/Modules/GoalModule.cs
+++ b/VGXPBotCore/Modules/GoalModule.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using System.Text;
+using System.Linq;
+using System.IO;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+
+using Discord;
+using Discord.WebSocket;
+using Discord.Commands;
+using Discord.Addons.Interactive;
+
+using System.Data.SQLite;
+
+namespace VGXPBotCore.Modules
+{
+  public class GoalModule : InteractiveBase
+  {
+
+    [RequireUserPermission(GuildPermission.KickMembers, Group = "Permission")]
+    [RequireOwner(Group = "Permission")]
+    [Command("goal")]
+    [Summary("`shows` the users on the bot database who achieved the specified goal.")]
+    [Alias("g")]
+    public async Task GoalAsync(int goal)
+    {
+
+      //Create and set users list
+      SocketUser user;
+
+      //Create and set embed object
+      var Achieved = CoreModule.SimpleEmbed(
+        Color.Green,
+        $"Users who achieved {goal} XP Fame",
+        null);
+
+      //Create and set embed object
+      var Achieved2 = CoreModule.SimpleEmbed(
+        Color.Green,
+        $"Users who achieved {goal} XP Fame (Cont.)",
+        null);
+
+      //Create and set embed object
+      var notAchieved = CoreModule.SimpleEmbed(
+        Color.Red,
+        $"Users who not achieved {goal} XP Fame",
+        null);
+
+      //Create and set embed object
+      var notAchieved2 = CoreModule.SimpleEmbed(
+        Color.Red,
+        $"Users who not achieved {goal} XP Fame (Cont.)",
+        null);
+
+      //Create and set user counter
+      int achievedCount = 0, notAchievedCount = 0;
+
+      //Create and set the database connection
+      using (SQLiteConnection dbConnection =
+        new SQLiteConnection($"Data Source = Databases/{Context.Guild.Id}.db; Version = 3;"))
+      {
+
+        //Open the connection
+        dbConnection.Open();
+
+        //Set query
+        using (SQLiteCommand dbCommand =
+          new SQLiteCommand("SELECT id, (actualXP - lastXP) as totalXP FROM users ORDER BY totalXP DESC;", dbConnection))
+        {
+
+          //Create and set the database reader from the command query
+          using (SQLiteDataReader dbDataReader = dbCommand.ExecuteReader())
+          {
+
+            //Read users stats info
+            while (dbDataReader.Read())
+            {
+
+              //Get the user id and convert to socketUser
+              user = Context.Guild.Users.FirstOrDefault(
+                x => x.Id == Convert.ToUInt64(dbDataReader["id"]));
+
+              //On goal achieved
+              if (Convert.ToInt32(dbDataReader["totalXP"]) >= goal)
+              {
+
+                //On less than 25 users
+                if (achievedCount < 25)
+                {
+
+                  //Add content to embed object
+                  Achieved.AddField($"**`{Convert.ToInt32(dbDataReader["totalXP"])}`**",
+                    user.Mention, true);
+                }
+
+                //On more that 25 users
+                else
+                {
+
+                  //Add content to embed object
+                  Achieved2.AddField($"**`{Convert.ToInt32(dbDataReader["totalXP"])}`**",
+                    user.Mention, true);
+                }
+
+                achievedCount++;
+              }
+
+              //On goal not achieved
+              else
+              {
+
+                //On less than 25 users
+                if (notAchievedCount < 25)
+                {
+
+                  //Add content to embed object
+                  notAchieved.AddField($"**`{Convert.ToInt32(dbDataReader["totalXP"])}`**",
+                    user.Mention, true);
+                }
+
+                //On more that 25 users
+                else
+                {
+
+                  //Add content to embed object
+                  notAchieved2.AddField($"**`{Convert.ToInt32(dbDataReader["totalXP"])}`**",
+                    user.Mention, true);
+                }
+
+                notAchievedCount++;
+              }
+
+
+            }
+          }
+        }
+      }
+
+      //On at least one user achieved the goal
+      if(achievedCount > 0)
+      {
+
+        //Reply embed
+        await ReplyAsync("", false, Achieved.Build());
+      }
+
+      //On more than 25 users achieved the goal
+      if(achievedCount > 25)
+      {
+
+        //Reply embed
+        await ReplyAsync("", false, Achieved2.Build());
+      }
+
+      //On at least one user not achieved the goal
+      if(notAchievedCount > 0)
+      {
+
+        //Reply embed
+        await ReplyAsync("", false, notAchieved.Build());
+      }
+
+      //On more than 25 users not achieved the goal
+      if(notAchievedCount > 25)
+      {
+
+        //Reply embed
+        await ReplyAsync("", false, notAchieved2.Build());
+      }
+    }
+  }
+}

--- a/VGXPBotCore/Modules/ListModule.cs
+++ b/VGXPBotCore/Modules/ListModule.cs
@@ -61,7 +61,7 @@ namespace VGXPBotCore.Modules
           using (SQLiteDataReader dbDataReader = dbCommand.ExecuteReader())
           {
 
-            //Read settings info
+            //Read users info
             while (dbDataReader.Read())
             {
               socketUser = Context.Guild.Users.FirstOrDefault(

--- a/VGXPBotCore/Program.cs
+++ b/VGXPBotCore/Program.cs
@@ -26,6 +26,8 @@ namespace VGXPBotCore
     //Bot token
     string token = GetToken("token.txt");
 
+    //TODO: UserLeftOnAbsence function
+
     public static void Main(string[] argss)
       => new Program().MainAsync().GetAwaiter().GetResult();
 


### PR DESCRIPTION
This module adds functionality to measure the user's XP fame on the server by comparing it against a specific XP goal. Either the user achieves the goal or not, simple as that. This module and it's implementation has been tested and it's working fine, it also has the extra embed objects for each table in case that the embed fields reach more than 25 fields.

[Add goal module](https://app.gitkraken.com/glo/board/5b9cb9f254d8310e006106bd/card/5e2e097f9a4c6500104aa726)