### PR TITLE
Add functionality for the bot when connecting back to the gateway (bot on absence)

### DIFF
--- a/VGXPBotCore/Modules/ListModule.cs
+++ b/VGXPBotCore/Modules/ListModule.cs
@@ -42,8 +42,6 @@ namespace VGXPBotCore.Modules
       //Create and set user counter
       int userCount = 0;
 
-      List<string> usersToDelete = new List<string>();
-
       //Create and set the database connection
       using (SQLiteConnection dbConnection =
         new SQLiteConnection($"Data Source = Databases/{Context.Guild.Id}.db; Version = 3;"))
@@ -67,63 +65,28 @@ namespace VGXPBotCore.Modules
               socketUser = Context.Guild.Users.FirstOrDefault(
                 x => x.Id == Convert.ToUInt64(dbDataReader["id"]));
 
-              //On user not found
-              if (socketUser == null)
+              //On less than 25 users
+              if (userCount < 25)
               {
 
-                usersToDelete.Add($"{dbDataReader["id"]}");
+                //Set embed content
+                embed.AddField($"{dbDataReader["name"]}", $"{socketUser.Mention}", true);
+
               }
 
-              //On user found
+              //On more than 25 users
               else
               {
 
-                //On less than 25 users
-                if (userCount < 25)
-                {
-
-                  //Set embed content
-                  embed.AddField($"{dbDataReader["name"]}", $"{socketUser.Mention}", true);
-
-                }
-
-                //On more than 25 users
-                else
-                {
-
-                  //Set embed content
-                  embed2.AddField($"{dbDataReader["name"]}", $"{socketUser.Mention}", true);
-                }
-
-                //Add counter
-                ++userCount;
+                //Set embed content
+                embed2.AddField($"{dbDataReader["name"]}", $"{socketUser.Mention}", true);
               }
+
+              //Add counter
+              ++userCount;
             }
           }
         }
-      }
-
-      //On users to delete
-      if(usersToDelete.Count != 0)
-      {
-        var embed3 = CoreModule.SimpleEmbed(
-          Color.Gold,
-          $"Users not found",
-          $"These users where deleted from the database, since they're not on the server");
-
-        for (int i = 0; i < usersToDelete.Count; ++i)
-        {
-
-          //Set embed content
-          embed3.AddField($"{i + 1}", $"<@{usersToDelete[i]}>", true);
-
-          //Execute query
-          CoreModule.ExecuteQuery(Context.Guild.Id,
-            $"DELETE FROM users WHERE id = {usersToDelete[i]};");
-        }
-
-        //Reply embed
-        await ReplyAsync("", false, embed3.Build());
       }
 
       //Set embed content

--- a/VGXPBotCore/Program.cs
+++ b/VGXPBotCore/Program.cs
@@ -280,7 +280,9 @@ namespace VGXPBotCore
           $"**`Not set`** - The guild role has to be **set by you**.\n" +
           $"**`Off`** -  The notifications are **Off** by default.\n" +
           $"**`Not set`** - The  notification's channel has to be **set by you**.\n\n" +
-          $"You can get more info about my commands using the **`~help`** command.");
+          $"You can get more info about my commands using the **`~help`** command.\n" +
+          $"(NOTE: The **`~help`** command shows the ones who the user can use based on it's " +
+          $"permissions on the server, most administration commands require the **`kick members`** permission.)");
 
         //Send message to channel
         server.DefaultChannel.SendMessageAsync("", false, embed.Build());

--- a/VGXPBotCore/Program.cs
+++ b/VGXPBotCore/Program.cs
@@ -275,7 +275,7 @@ namespace VGXPBotCore
         var embed = Modules.CoreModule.SimpleEmbed(
           Color.Gold,
           $"Thank you for adding me to your server!",
-          $"Seems I was added while I was sleeping, these is my default configuration:\n" +
+          $"Seems I was added while I was sleeping, this is my default configuration:\n" +
           $"**`~`** - This is my default prefix.\n" +
           $"**`Not set`** - The guild role has to be **set by you**.\n" +
           $"**`Off`** -  The notifications are **Off** by default.\n" +

--- a/VGXPBotCore/VGXPBotCore.csproj
+++ b/VGXPBotCore/VGXPBotCore.csproj
@@ -6,11 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Costura.Fody" Version="3.3.3" />
-    <PackageReference Include="Discord.Addons.PassiveInteractive" Version="2.0.3" />
-    <PackageReference Include="Discord.Net" Version="2.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="System.Data.SQLite" Version="1.0.110" />
+    <PackageReference Include="Costura.Fody" Version="4.1.0" />
+    <PackageReference Include="Discord.Addons.PassiveInteractive" Version="2.0.4" />
+    <PackageReference Include="Discord.Net" Version="2.1.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.112" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The new functionality added to the bot is when the bot reconnects to the Discord gateway servers (mostly because the bot was on maintenance or the bot was with connection issues). The main functions added are when the bot was added to any new server while it was offline, sending a thank you message for adding it to the server and explaining about the default configurations the bot has and what's needed to set up after the addition (this is checked if the server has a database or not, if the case was the later, then it creates it and sends the message, otherwise not). The other functionality added is when on an already existing server some users have left while the bot was offline AND those users where part of the database of that server, this new addition checks if any user on the database is still on the server or not, in case of the later, the bot deletes them and displays an embed object with the users deleted, in case that no user has left the server, then everything is fine.

![image](https://user-images.githubusercontent.com/29107481/73164172-02e55c00-40b7-11ea-8791-b73903436664.png)
![image](https://user-images.githubusercontent.com/29107481/73163931-8c485e80-40b6-11ea-93be-85b450894b13.png)

These additions are vital for a better understanding of the bot when adding it for the first time, but the bot was offline. Also it takes out the burden of the users with the right permissions to verify if any users from the database are no longer on the server, and cause any issues using the bot commands because of missing users (this happens due to the checks made when getting the data from the database and comparing it with the server data, mostly causing logic errors).

[Add OnAbsence functionality on Bot startup](https://app.gitkraken.com/glo/board/5b9cb9f254d8310e006106bd/card/5e2e4eff9a4c6500104aabb8)